### PR TITLE
feat: add error option to waitForCondition

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ Takes a condition (a function returning a boolean or boolean promise),
 and waits until the condition is true.
 
 Throws a `/Condition unmet/` error if the condition has not been
-satisfied within the allocated time.
+satisfied within the allocated time, unless an error is provided in
+the options, as the `error` property, which is either thrown itself, or
+used as the message.
 
 The condition result is returned if it is not falsy. If the condition
 throws an error then this exception will be immediately passed through.
@@ -149,6 +151,25 @@ await waitForCondition(condFn, {
   intervalMs: 10000
   logger: myLogger // expects a debug method
 });
+
+// pass an error string to get that message in the resulting exception
+try {
+  await waitForCondition(condFn, {
+    error: 'Unable to satisfy condition'
+  });
+} catch (err) {
+  // err.message === 'Unable to satisfy condition'
+}
+
+// pass an error instance to be thrown
+const error = new Error('Unable to satisfy condition');
+try {
+  await waitForCondition(condFn, {
+    error: error
+  });
+} catch (err) {
+  // err === error
+}
 ```
 
 ### Run the tests

--- a/lib/asyncbox.js
+++ b/lib/asyncbox.js
@@ -105,22 +105,26 @@ async function waitForCondition (condFn, opts = {}) {
     waitMs: 5000,
     intervalMs: 500,
   });
-  let debug = opts.logger ? opts.logger.debug.bind(opts.logger) : _.noop;
-  let begunAt = Date.now();
-  let endAt = begunAt + opts.waitMs;
-  let spin = async () => {
+  const debug = opts.logger ? opts.logger.debug.bind(opts.logger) : _.noop;
+  const error = opts.error;
+  const begunAt = Date.now();
+  const endAt = begunAt + opts.waitMs;
+  const spin = async function spin () {
     const result = await condFn();
     if (result) {
       return result;
     }
-    let now = Date.now();
-    let waited = now - begunAt;
+    const now = Date.now();
+    const waited = now - begunAt;
     if (now < endAt) {
       debug(`Waited for ${waited} ms so far`);
       await B.delay(opts.intervalMs);
       return await spin();
     }
-    throw new Error(`Condition unmet after ${waited} ms. Timing out.`);
+    // if there is an error option, it is either a string message or an error itself
+    throw error
+      ? (_.isString(error) ? new Error(error) : error)
+      : new Error(`Condition unmet after ${waited} ms. Timing out.`);
   };
   return await spin();
 }


### PR DESCRIPTION
Add an option to `waitForCondition` to configure the error that is returned. This is modeled after Bluebird's [timeout](http://bluebirdjs.com/docs/api/timeout.html) functionality.

Currently, to not expose the condition unmet error, the usage of `waitForCondition` is something like
```js
try {
  await waitForCondition(condFn);
} catch (err) {
  if (err.message.includes('Condition unmet')) {
    throw new Error('Unable to do whatever we are trying to do');
  }
  throw err;
}
```

This PR will allow a more streamlined
```js
await waitForCondition(condFn, {
  error: 'Unable to do whatever we are trying to do',
});