### PR TITLE
Jay/Sriram : Change logic of InternalPooling time to avoid exceeding Implicit WaitTime

### DIFF
--- a/lib/asyncbox.js
+++ b/lib/asyncbox.js
@@ -141,9 +141,10 @@ async function waitForCondition (condFn, opts = {}) {
     }
     const now = Date.now();
     const waited = now - begunAt;
+    const remainingTime = endAt - now;
     if (now < endAt) {
       debug(`Waited for ${waited} ms so far`);
-      await B.delay(opts.intervalMs);
+      await B.delay(Math.min(opts.intervalMs, remainingTime));
       return await spin();
     }
     // if there is an error option, it is either a string message or an error itself

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "bluebird": "^3.5.1",
     "es6-mapify": "^1.1.0",
     "lodash": "^4.17.4",
+    "sinon": "^11.1.2",
     "source-map-support": "^0.5.5"
   },
   "scripts": {


### PR DESCRIPTION
Hi,

We observed scenarios where MaxTimeOut is getting exceeded during last condition check 

So creating this PR to validate whether remaining time is lesser than internal pooling time, if yes we will use remaining Time as next pooling time or we will continue as default.

Benefits of It:
1. We will not wait for additional time apart from the configured Timeout(waitMs) to do the last condition check

Co-authored-by: Sriram <sriramsubramanian.btech@gmail.com>

Thanks
Jayandran/ Sriram