### PR TITLE
feat(): add types

### DIFF
--- a/lib/asyncbox.js
+++ b/lib/asyncbox.js
@@ -1,15 +1,32 @@
 // transpile:main
 
 import B from 'bluebird';
-import { mapify } from 'es6-mapify';
 import _ from 'lodash';
 
 const LONG_SLEEP_THRESHOLD = 5000; // anything over 5000ms will turn into a spin
 
+/**
+ * An async/await version of setTimeout
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
 async function sleep (ms) {
   return await B.delay(ms);
 }
 
+/**
+ * Sometimes `Promise.delay` or `setTimeout` are inaccurate for large wait
+ * times. To safely wait for these long times (e.g. in the 5+ minute range), you
+ * can use `longSleep`.
+ *
+ * sYou can also pass a `progressCb` option which is a callback function that
+ * receives an object with the properties `elapsedMs`, `timeLeft`, and
+ * `progress`. This will be called on every wait interval so you can do your
+ * wait logging or whatever.
+ * @param {number} ms
+ * @param {LongSleepOptions} [opts]
+ * @returns {Promise<void>}
+ */
 async function longSleep (ms, {
   thresholdMs = LONG_SLEEP_THRESHOLD,
   intervalMs = 1000,
@@ -33,6 +50,14 @@ async function longSleep (ms, {
   } while (timeLeft > 0);
 }
 
+/**
+ * An async/await way of running a method until it doesn't throw an error
+ * @template [T=any]
+ * @param {number} times
+ * @param {(...args: any[]) => Promise<T>} fn
+ * @param  {...any} args
+ * @returns {Promise<T?>}
+ */
 async function retry (times, fn, ...args) {
   let tries = 0;
   let done = false;
@@ -51,6 +76,16 @@ async function retry (times, fn, ...args) {
   return res;
 }
 
+/**
+ * You can also use `retryInterval` to add a sleep in between retries. This can
+ * be useful if you want to throttle how fast we retry.
+ * @template [T=any]
+ * @param {number} times
+ * @param {number} sleepMs
+ * @param {(...args: any[]) => Promise<T>} fn
+ * @param  {...any} args
+ * @returns {Promise<T?>}
+ */
 async function retryInterval (times, sleepMs, fn, ...args) {
   let count = 0;
   let wrapped = async () => {
@@ -70,17 +105,29 @@ async function retryInterval (times, sleepMs, fn, ...args) {
   return await retry(times, wrapped);
 }
 
-async function parallel (promises) {
-  return await B.all(promises);
-}
+const parallel = B.all;
 
+/**
+ * Export async functions (Promises) and import this with your ES5 code to use
+ * it with Node.
+ * @template [R=any]
+ * @param {any} promisey
+ * @param {(err: any, value?: R) => void} cb
+ * @returns {Promise<R>}
+ */
 function nodeify (promisey, cb) { // eslint-disable-line promise/prefer-await-to-callbacks
   return B.resolve(promisey).nodeify(cb);
 }
 
+/**
+ * Node-ify an entire object of `Promise`-returning functions
+ * @param {Record<string,(...args: any[]) => any>} promiseyMap
+ * @returns {Record<string,(...args: any[])=>void>}
+ */
 function nodeifyAll (promiseyMap) {
+  /** @type {Record<string,(...args: any[])=>void>} */
   let cbMap = {};
-  for (const [name, fn] of mapify(promiseyMap)) {
+  for (const [name, fn] of _.toPairs(promiseyMap)) {
     cbMap[name] = function (...args) {
       const _cb = args.slice(-1)[0];
       args = args.slice(0, -1);
@@ -90,10 +137,20 @@ function nodeifyAll (promiseyMap) {
   return cbMap;
 }
 
+/**
+ * @param {(...args: any[]) => any|Promise<any>} fn
+ * @param  {...any} args
+ */
 function asyncify (fn, ...args) {
   B.resolve(fn(...args)).done();
 }
 
+/**
+ * Similar to `Array.prototype.map`; runs in serial
+ * @param {any[]} coll
+ * @param {(value: any) => any|Promise<any>} mapper
+ * @returns {Promise<any[]>}
+ */
 async function asyncmap (coll, mapper, runInParallel = true) {
   if (runInParallel) {
     return parallel(coll.map(mapper));
@@ -106,6 +163,13 @@ async function asyncmap (coll, mapper, runInParallel = true) {
   return newColl;
 }
 
+/**
+ * Similar to `Array.prototype.filter`
+ * @param {any[]} coll
+ * @param {(value: any) => any|Promise<any>} filter
+ * @param {boolean} runInParallel
+ * @returns {Promise<any[]>}
+ */
 async function asyncfilter (coll, filter, runInParallel = true) {
   let newColl = [];
   if (runInParallel) {
@@ -125,8 +189,26 @@ async function asyncfilter (coll, filter, runInParallel = true) {
   return newColl;
 }
 
-async function waitForCondition (condFn, opts = {}) {
-  _.defaults(opts, {
+/**
+ * Takes a condition (a function returning a boolean or boolean promise), and
+ * waits until the condition is true.
+ *
+ * Throws a `/Condition unmet/` error if the condition has not been satisfied
+ * within the allocated time, unless an error is provided in the options, as the
+ * `error` property, which is either thrown itself, or used as the message.
+ *
+ * The condition result is returned if it is not falsy. If the condition throws an
+ * error then this exception will be immediately passed through.
+ *
+ * The default options are: `{ waitMs: 5000, intervalMs: 500 }`
+ * @template T
+ * @param {() => Promise<T>|T} condFn
+ * @param {WaitForConditionOptions} [options]
+ * @returns {Promise<T>}
+ */
+async function waitForCondition (condFn, options = {}) {
+  /** @type {WaitForConditionOptions & {waitMs: number, intervalMs: number}} */
+  const opts = _.defaults(options, {
     waitMs: 5000,
     intervalMs: 500,
   });
@@ -134,6 +216,7 @@ async function waitForCondition (condFn, opts = {}) {
   const error = opts.error;
   const begunAt = Date.now();
   const endAt = begunAt + opts.waitMs;
+  /** @returns {Promise<T>} */
   const spin = async function spin () {
     const result = await condFn();
     if (result) {
@@ -159,3 +242,35 @@ export {
   sleep, retry, nodeify, nodeifyAll, retryInterval, asyncify, parallel,
   asyncmap, asyncfilter, waitForCondition, longSleep,
 };
+
+/**
+ * Options for {@link waitForCondition}
+ * @typedef WaitForConditionOptions
+ * @property {number} [waitMs]
+ * @property {number} [intervalMs]
+ * @property {{debug: (...args: any[]) => void}} [logger]
+ * @property {string|Error} [error]
+ */
+
+/**
+ * Options for {@link longSleep}
+ * @typedef LongSleepOptions
+ * @property {number} [thresholdMs]
+ * @property {number} [intervalMs]
+ * @property {ProgressCallback?} [progressCb]
+ */
+
+/**
+ * Parameter provided to a {@link ProgressCallback}
+ * @typedef Progress
+ * @property {number} elapsedMs
+ * @property {number} timeLeft
+ * @property {number} progress
+ */
+
+/**
+ * Progress callback for {@link longSleep}
+ * @callback ProgressCallback
+ * @param {Progress} progress
+ * @returns {void}
+ */

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   "bugs": {
     "url": "https://github.com/jlipps/asyncbox/issues"
   },
-  "engines": [
-    "node"
-  ],
+  "engines": {
+    "node": ">=10"
+  },
   "main": "./build/lib/asyncbox.js",
   "bin": {},
   "directories": {
@@ -31,20 +31,21 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "bluebird": "^3.5.1",
-    "es6-mapify": "^1.1.0",
     "lodash": "^4.17.4",
-    "source-map-support": "^0.5.5"
+    "source-map-support": "^0.5.5",
+    "@types/bluebird": "^3.5.37"
   },
   "scripts": {
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
-    "prepare": "gulp prepublish",
+    "prepare": "gulp prepublish && tsc",
     "test": "gulp once",
     "e2e-test": "gulp e2e-test",
-    "build": "gulp transpile",
+    "build": "gulp transpile && tsc",
     "lint": "gulp eslint",
     "watch": "gulp watch"
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.189",
     "ajv": "^6.5.3",
     "appium-gulp-plugins": "^4.0.0",
     "chai": "4.2.0",
@@ -53,6 +54,8 @@
     "gulp": "^4.0.0",
     "request": "^2.47.0",
     "should": "^13.2.1",
-    "sinon": "^11.1.2"
-  }
+    "sinon": "^11.1.2",
+    "typescript": "^4.7.0"
+  },
+  "types": "./build/lib/asyncbox.d.ts"
 }

--- a/test/asyncbox-specs.js
+++ b/test/asyncbox-specs.js
@@ -148,6 +148,7 @@ describe('retry', function () {
       let res = await retryInterval(3, 15, eventuallyOkNoSleepFn, 3);
       eventuallyOkFnCalls.should.equal(3);
       res.should.equal(9);
+      // XXX: flaky
       (Date.now() - start).should.be.above(30);
     });
     it('should not wait on the final error', async function () {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "strict": true,
+    "allowJs": true,
+    "checkJs": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "moduleResolution": "node",
+    "outDir": "build"
+  },
+  "include": ["lib"]
+}


### PR DESCRIPTION
Got sick of no types, so I added types.

A few other things:

- Re-exports `B.all` as `parallel` since that's all the function was doing anyway
- Removed `es6-mapify` since a) it _also_ needs types, and b) it was not actually needed
- Fixes bad `engines` field in `package.json`