### PR TITLE
feat: Publish dual CJS and ESM builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A collection of ES7 async/await utilities. Install via NPM:
 npm install asyncbox
 ```
 
+Published as both ESM and CommonJS, so `import {sleep} from 'asyncbox'` and `const {sleep} = require('asyncbox')` both work.
+
 Then, behold!
 
 ### Sleep

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "scripts": {
     "build": "tsc -b tsconfig.esm.json tsconfig.cjs.json",
     "postbuild": "node scripts/postbuild.mjs",
-    "clean": "npm run build -- --clean",
+    "clean": "rm -rf build",
     "rebuild": "npm run clean; npm run build",
     "dev": "npm run build -- --watch",
     "prepare": "npm run rebuild",

--- a/package.json
+++ b/package.json
@@ -20,22 +20,42 @@
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
     "npm": ">=10"
   },
-  "main": "./build/lib/asyncbox.js",
+  "type": "module",
+  "main": "./build/cjs/lib/asyncbox.js",
+  "module": "./build/esm/lib/asyncbox.js",
+  "types": "./build/cjs/lib/asyncbox.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./build/esm/lib/asyncbox.d.ts",
+        "default": "./build/esm/lib/asyncbox.js"
+      },
+      "require": {
+        "types": "./build/cjs/lib/asyncbox.d.ts",
+        "default": "./build/cjs/lib/asyncbox.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
   "bin": {},
   "directories": {
     "lib": "./lib"
   },
   "files": [
     "lib/**/*",
-    "build/lib/**/*"
+    "build/cjs/lib/**/*",
+    "build/cjs/package.json",
+    "build/esm/lib/**/*",
+    "build/esm/package.json"
   ],
   "scripts": {
-    "build": "tsc -b",
+    "build": "tsc -b tsconfig.esm.json tsconfig.cjs.json",
+    "postbuild": "node scripts/postbuild.mjs",
     "clean": "npm run build -- --clean",
     "rebuild": "npm run clean; npm run build",
     "dev": "npm run build -- --watch",
     "prepare": "npm run rebuild",
-    "test": "node --test --enable-source-maps --test-force-exit --test-timeout=60000 \"./build/test/**/*.spec.js\"",
+    "test": "node --test --enable-source-maps --test-force-exit --test-timeout=60000 \"./build/esm/test/**/*.spec.js\" \"./test/*.spec.cjs\"",
     "lint": "eslint .",
     "format": "prettier -w ./lib ./test",
     "format:check": "prettier --check ./lib ./test",
@@ -59,6 +79,5 @@
     "prettier": "^3.0.0",
     "semantic-release": "^25.0.2",
     "typescript": "^6.0.3"
-  },
-  "types": "./build/lib/asyncbox.d.ts"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "scripts": {
     "build": "tsc -b tsconfig.esm.json tsconfig.cjs.json",
     "postbuild": "node scripts/postbuild.mjs",
-    "clean": "rm -rf build",
+    "clean": "node scripts/clean.mjs",
     "rebuild": "npm run clean; npm run build",
     "dev": "npm run build -- --watch",
     "prepare": "npm run rebuild",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "scripts": {
     "build": "tsc -b tsconfig.esm.json tsconfig.cjs.json",
     "postbuild": "node scripts/postbuild.mjs",
-    "clean": "node scripts/clean.mjs",
+    "clean": "node -e \"require('fs').rmSync('build', {recursive: true, force: true})\"",
     "rebuild": "npm run clean; npm run build",
     "dev": "npm run build -- --watch",
     "prepare": "npm run rebuild",

--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -1,3 +1,0 @@
-import {rmSync} from 'node:fs';
-
-rmSync('build', {recursive: true, force: true});

--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -1,0 +1,3 @@
+import {rmSync} from 'node:fs';
+
+rmSync('build', {recursive: true, force: true});

--- a/scripts/postbuild.mjs
+++ b/scripts/postbuild.mjs
@@ -1,0 +1,9 @@
+import {mkdirSync, writeFileSync} from 'node:fs';
+
+for (const [dir, type] of [
+  ['build/esm', 'module'],
+  ['build/cjs', 'commonjs'],
+]) {
+  mkdirSync(dir, {recursive: true});
+  writeFileSync(`${dir}/package.json`, `${JSON.stringify({type}, null, 2)}\n`);
+}

--- a/test/cjs-interop.spec.cjs
+++ b/test/cjs-interop.spec.cjs
@@ -1,6 +1,8 @@
 const assert = require('node:assert/strict');
 const {test} = require('node:test');
-const asyncbox = require('../build/cjs/lib/asyncbox.js');
+// Requires the package by name (rather than a build path) so this exercises the same
+// "exports"/"main" resolution real CommonJS consumers go through.
+const asyncbox = require('asyncbox');
 
 test('require() interop with the CJS build', async () => {
   assert.equal(typeof asyncbox.sleep, 'function');

--- a/test/cjs-interop.spec.cjs
+++ b/test/cjs-interop.spec.cjs
@@ -1,0 +1,9 @@
+const assert = require('node:assert/strict');
+const {test} = require('node:test');
+const asyncbox = require('../build/cjs/lib/asyncbox.js');
+
+test('require() interop with the CJS build', async () => {
+  assert.equal(typeof asyncbox.sleep, 'function');
+  assert.equal(typeof asyncbox.retry, 'function');
+  await asyncbox.sleep(1);
+});

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "build/cjs",
+    "module": "CommonJS",
+    "moduleResolution": "Bundler"
+  }
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "build/esm"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,12 +3,12 @@
   "extends": "@appium/tsconfig/tsconfig.json",
   "compilerOptions": {
     "strict": true,
-    "outDir": "build",
     "types": ["node"],
     "checkJs": true
   },
   "include": [
     "lib",
     "test"
-  ]
+  ],
+  "exclude": ["test/*.cjs"]
 }


### PR DESCRIPTION
Publish both a CommonJS and an ESM build from the same TypeScript source (build/cjs and build/esm, each with its own package.json marker), so existing require('asyncbox') consumers keep working unchanged while new consumers can import it natively. Wired up via a conditional exports map (plus main/module/types fallbacks) and a postbuild script that stamps each output directory with its own {"type": ...}.

p-limit (a runtime dependency) is ESM-only. The CJS build's require('p-limit') works because it relies on Node's native require(esm) support, available on the versions already required by engines (^20.19.0 || ^22.12.0 || >=24.0.0). tsconfig.cjs.json uses moduleResolution: "Bundler" (paired with module: "CommonJS") so tsc can resolve p-limit's types, which only exist under its exports field with no top-level main/types.

Also add test/cjs-interop.spec.cjs, which require()s the CJS build directly, so a future change that breaks CJS consumption (e.g. an ESM-only dependency bump) fails CI instead of only being caught by the ESM test suite.

Lint/format/release tooling changes are intentionally left out of this PR per https://github.com/appium/asyncbox/pull/84#issuecomment-5079412189.